### PR TITLE
Add ability to use custom element tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ import ContentEditable from 'react-simple-contenteditable';
 class App extends Component {
   constructor (props) {
     super(props);
-    
+
     this.state = {
       title: "Title here"
     }
@@ -35,6 +35,7 @@ class App extends Component {
         <ContentEditable
           html={this.state.title}
           className="my-class"
+          tagName="h1"
           onChange={ this.handleChange }
           contentEditable="plaintext-only"
         />

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,16 +76,20 @@ var ContentEditable = function (_Component) {
     key: 'render',
     value: function render() {
       var _props2 = this.props,
+          tagName = _props2.tagName,
           html = _props2.html,
           contentEditable = _props2.contentEditable,
-          props = _objectWithoutProperties(_props2, ['html', 'contentEditable']);
+          props = _objectWithoutProperties(_props2, ['tagName', 'html', 'contentEditable']);
 
-      return _react2.default.createElement('div', _extends({}, props, {
+      var Element = tagName || "div";
+
+      return _react2.default.createElement(Element, _extends({}, props, {
         ref: 'element',
         dangerouslySetInnerHTML: { __html: html },
         contentEditable: contentEditable === 'false' ? false : true,
         onInput: this._onChange,
-        onPaste: this._onPaste }));
+        onPaste: this._onPaste
+      }));
     }
   }]);
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "react-simple-contenteditable",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A simple contenteditable component",
   "main": "lib/index.js",
   "repository": "https://github.com/raphasilvac/react-simple-contenteditable.git",
   "author": "Raphael Silva Cavalcanti",
+  "contributors": [
+    "Ashley Williams <hi@ashleyw.co.uk>"
+  ],
   "license": "MIT",
   "dependencies": {
     "react": "^15.4.2"

--- a/src/react-simple-contenteditable.js
+++ b/src/react-simple-contenteditable.js
@@ -38,17 +38,19 @@ export default class ContentEditable extends Component {
   }
 
   render () {
-    const { html, contentEditable, ...props } = this.props;
+    const { tagName, html, contentEditable, ...props } = this.props;
+
+    const Element = tagName || "div";
 
     return (
-      <div
+      <Element
         {...props}
         ref="element"
-        dangerouslySetInnerHTML={{__html: html}}
+        dangerouslySetInnerHTML={{ __html: html }}
         contentEditable={ contentEditable === 'false' ? false : true }
         onInput={ this._onChange }
-        onPaste={ this._onPaste } >
-      </div>
+        onPaste={ this._onPaste }
+      />
     )
   }
 }


### PR DESCRIPTION
Added the ability to pass a `tagName` prop. Useful for `h1` contenteditable elements.